### PR TITLE
Fix ECS permisions.

### DIFF
--- a/doc_source/auth-and-access-control.md
+++ b/doc_source/auth-and-access-control.md
@@ -125,7 +125,7 @@ Users must have additional permissions for each type of resource they must add t
 
 **ECS services**
 + `ecs:DescribeServices`
-+ `ecs:UpdateServices`
++ `ecs:UpdateService`
 
 **Spot Fleet requests**
 + `ec2:DescribeSpotFleetRequests`


### PR DESCRIPTION
`ecs:UpdateServices` action does not exist. A scaling plan fails to be created with the following exception.

    User is missing the following permissions: [ecs:UpdateService]

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
